### PR TITLE
PLATUI-629: Enabled SbtAutoBuildPlugin. 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,36 +1,17 @@
-import sbt.Keys._
-import sbt._
-import sbt.plugins.{CorePlugin, IvyPlugin, JvmPlugin}
-
 lazy val root = (project in file("."))
   .enablePlugins(GatlingPlugin)
-  .enablePlugins(CorePlugin)
-  .enablePlugins(JvmPlugin)
-  .enablePlugins(IvyPlugin)
+  .enablePlugins(SbtAutoBuildPlugin)
   .settings(
     name := "accessibility-statement-performance-tests",
     version := "0.1.0-SNAPSHOT",
     scalaVersion := "2.12.12",
-    libraryDependencies ++= Seq(
-      Dependencies.Compile.typesafeConfig,
-      Dependencies.Compile.gatlingHighCharts,
-      Dependencies.Compile.gatlingTestFramework,
-      Dependencies.Compile.performanceTestRunner
-    ),
-    scalacOptions ++= Seq(
-      "-unchecked",
-      "-deprecation",
-      "-Xlint",
-      "-language:_",
-      "-target:jvm-1.8",
-      "-Xmax-classfile-name", "100",
-      "-encoding", "UTF-8"
-    ),
+    libraryDependencies ++= Dependencies.test,
+    //implicitConversions & postfixOps are Gatling recommended -language settings
+    scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-language:postfixOps"),
     javaOptions in Gatling ++= overrideDefaultJavaOptions("-Xms4096m", "-Xmx16384m"),
-    retrieveManaged := true,
-    initialCommands in console := "import uk.gov.hmrc._",
-    parallelExecution in Test := false,
-    publishArtifact in Test := true,
+    // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.
+    // These testOptions are not compatible with `sbt gatling:test`. So we have to override testOptions here.
+    testOptions in Test := Seq.empty,
     resolvers ++= Seq(
       Resolver.bintrayRepo("hmrc", "releases"),
       Resolver.typesafeRepo("releases")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,11 +4,11 @@ object Dependencies {
 
   private val gatlingVersion = "2.3.1"
 
-  object Compile {
-    val typesafeConfig = "com.typesafe" % "config" % "1.3.1"
-    val performanceTestRunner = "uk.gov.hmrc" %% "performance-test-runner" % "3.7.0"
-    val gatlingTestFramework = "io.gatling" % "gatling-test-framework" % gatlingVersion
-    val gatlingHighCharts = "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion
-  }
+  val test = Seq(
+    "com.typesafe" % "config" % "1.3.1" % Test,
+    "uk.gov.hmrc" %% "performance-test-runner" % "3.7.0" % Test,
+    "io.gatling" % "gatling-test-framework" % gatlingVersion % Test,
+    "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion % Test
+  )
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,6 @@
 resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
   Resolver.ivyStylePatterns)
 
-resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
-
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
 
 addSbtPlugin("io.gatling" % "gatling-sbt" % "2.2.2")

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,3 +1,16 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # The default url for every service.
 # For example

--- a/src/test/resources/gatling.conf
+++ b/src/test/resources/gatling.conf
@@ -1,3 +1,17 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #########################
 # Gatling Configuration #
 #########################

--- a/src/test/resources/journeys.conf
+++ b/src/test/resources/journeys.conf
@@ -1,3 +1,17 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Configure here your journeys. A journey is a sequence of requests at a certain load.
 
 journeys {

--- a/src/test/resources/services-local.conf
+++ b/src/test/resources/services-local.conf
@@ -1,3 +1,16 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This file is read when runLocal = true in application.conf (default)
 

--- a/src/test/resources/services.conf
+++ b/src/test/resources/services.conf
@@ -1,3 +1,16 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This file is read when runLocal = false in application.conf (default is false)
 

--- a/src/test/scala/uk/gov/hmrc/perftests/example/AccessibilityStatementFrontendRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/example/AccessibilityStatementFrontendRequests.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.perftests.example
 
 import uk.gov.hmrc.performance.conf.ServicesConfiguration

--- a/src/test/scala/uk/gov/hmrc/perftests/example/AccessibilityStatementFrontendSimulation.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/example/AccessibilityStatementFrontendSimulation.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.perftests.example
 
 import uk.gov.hmrc.performance.simulation.PerformanceTestRunner


### PR DESCRIPTION
This brings in required Scala compiler settings. This also generates copyright headers.

`SbtAutoBuildPlugin` provides `testOptions in Test` which is not compatible with `sbt gatling:test`. Hence requires overriding.
Removed existing scalac `-language` settings as this was using a wildcard option. Added Gatling specific Scala Compiler language settings.
Introduced `-feature` flag to surface detailed warning messages when using advanced Scala language features without relevant settings/imports.
Marked all dependencies as Test and refactored them into a Seq.
`CorePlugin, JvmPlugin, IvyPlugin` are auto-enabled. So they do not need to be explicitly enabled.

**Removed the below settings:**
`retrieveManaged := true` // required only when a project specific local ivy_cache is required.
`initialCommands in console := "import uk.gov.hmrc._"` // required only when sbt console requires to be launched with this initial command.
`parallelExecution in Test := false` // provided by SbtAutoBuild plugin
`publishArtifact in Test := true` // not required unless a jar file for test classes and resources needs publishing.